### PR TITLE
FIX: requests_cache was required but not in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,6 @@ setup(
         'flask',
         'pandas_datareader',
         'pyquery',
+        'requests_cache'
     ],
 )


### PR DESCRIPTION
When trying to setup and run this project I noticed that `` requests_cache `` needed to be installed in order to execute `` run.py ``, but was not included in the `` setup.py `` file.

As I'd like to contribute to this project I figured this might be a good little fix to start this.